### PR TITLE
Add extra information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,5 +40,6 @@
 
 # MODEL='facebook/opt-125m'
 # MODEL_NAME="?"
+# DEFAULT_EXTRA_INFORMATION='facebook/extra_information.json'
 ### You can also put any args from vllm concerning the model defined in (https://github.com/vllm-project/vllm/blob/main/vllm/engine/arg_utils.py) such
 ### as TRUST_REMOTE_CODE, DTYPE, MAX_MODEL_LEN, GPU_MEMORY_UTILIZATION, ...

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -21,6 +21,7 @@ Here is a list of arguments useful for the application (they all have default va
  - `host` : The name of the host (default value is `127.0.0.1`)
  - `port` : The port number (default value is `5000`)
  - `model-name` : The name of the model which will be given by the `/v1/info` endpoint or the `/v1/models`. Knowing the name of the model is important to be able to use the endpoints `/v1/completions` and `/v1/chat/completions` (default value is `?`)
+ - `extra-information` : The path to a json which will be added to the `/v1/info` endpoint in the `extra_information` field 
  - `app-name`: The name of the application (default value is `happy_vllm`)
  - `api-endpoint-prefix`: The prefix added to all the API endpoints (default value is no prefix)
  - `explicit-errors`: If `False`, the message displayed when an `500 error` is encountered will be `Internal Server Error`. If `True`, the message displayed will be more explicit and give information on the underlying error. The `True` setting is not recommended in a production setting (default value is `False`).

--- a/docs/endpoints/technical.md
+++ b/docs/endpoints/technical.md
@@ -13,9 +13,11 @@ This endpoints gives various information on the application and the model. The f
   "vllm_version": "0.4.0.post1",
   "model_name": "The best LLM",
   "truncation_side": "right",
-  "max_length": 32768
+  "max_length": 32768,
+  "extra_information": {}
 }
 ```
+In order to add a non empty dictionnary to the field "extra_information", you should pass the path to .json when initiating the API via the `--extra-information` argument.
 
 ## /metrics (GET)
 

--- a/src/happy_vllm/model/model_base.py
+++ b/src/happy_vllm/model/model_base.py
@@ -71,7 +71,7 @@ class Model:
         """load the model"""
         await self._load_model(async_engine_client, args, **kwargs)
         self._loaded = True
-        if args.extra_information is not None:
+        if args.extra_information:
             with open(args.extra_information, 'r') as json_file:
                 self.extra_information = json.load(json_file)
         if args.with_launch_arguments:

--- a/src/happy_vllm/model/model_base.py
+++ b/src/happy_vllm/model/model_base.py
@@ -20,6 +20,7 @@
 
 
 import os
+import json
 import asyncio
 import logging
 from pathlib import Path
@@ -60,6 +61,7 @@ class Model:
         self.openai_serving_tokenization = None
         self._loaded = False
         self.app_name = kwargs.get('app_name', "happy_vllm")
+        self.extra_information = {}
 
     def is_model_loaded(self):
         """return the state of the model"""
@@ -69,6 +71,9 @@ class Model:
         """load the model"""
         await self._load_model(async_engine_client, args, **kwargs)
         self._loaded = True
+        if args.extra_information is not None:
+            with open(args.extra_information, 'r') as json_file:
+                self.extra_information = json.load(json_file)
         if args.with_launch_arguments:
             self.launch_arguments = vars(args)
         else:

--- a/src/happy_vllm/routers/schemas/technical.py
+++ b/src/happy_vllm/routers/schemas/technical.py
@@ -63,6 +63,7 @@ class ResponseInformation(BaseModel):
     model_name: str = Field(None, title="Model name")
     truncation_side: str = Field(None, title="Truncation side")
     max_length : int = Field(None, title="Max length")
+    extra_information: dict = Field(None, title="Extra information")
     model_config = {
         "json_schema_extra": {
             "examples": [

--- a/src/happy_vllm/routers/technical.py
+++ b/src/happy_vllm/routers/technical.py
@@ -77,7 +77,8 @@ async def info() -> technical_schema.ResponseInformation:
         model_name=model._model_conf.get("model_name", "?"),
         vllm_version=utils.get_vllm_version(),
         truncation_side=model.original_truncation_side,
-        max_length=model.max_model_len
+        max_length=model.max_model_len,
+        extra_information=model.extra_information
     )
 
 

--- a/src/happy_vllm/utils_args.py
+++ b/src/happy_vllm/utils_args.py
@@ -35,6 +35,7 @@ from vllm.config import (ConfigFormat, TaskOption, HfOverrides, PoolerConfig, Co
 
 
 DEFAULT_MODEL_NAME = '?'
+DEFAULT_EXTRA_INFORMATION = None
 DEFAULT_APP_NAME = "happy_vllm"
 DEFAULT_API_ENDPOINT_PREFIX = ""
 DEFAULT_HOST = "127.0.0.1"
@@ -118,12 +119,12 @@ class ApplicationSettings(BaseSettings):
 
 
 def get_model_settings(parser: FlexibleArgumentParser) -> BaseSettings:
-    """Gets the model settings. It corresponds to the variables added via AsyncEngineArgs.add_cli_args plus model-name.
+    """Gets the model settings. It corresponds to the variables added via AsyncEngineArgs.add_cli_args plus model-name and extra-information.
     First we use the parser to get the default values of vLLM for these variables. We instantiate a BaseSettings model
     with these values as default. They are possibly overwritten by environnement variables or those of a .env
 
     Args:
-        parser (FlexibleArgumentParser) : The parser containing all the model variables with thei default values from vLLM 
+        parser (FlexibleArgumentParser) : The parser containing all the model variables with their default values from vLLM 
     """
 
     default_args = parser.parse_args([])
@@ -132,6 +133,7 @@ def get_model_settings(parser: FlexibleArgumentParser) -> BaseSettings:
     class ModelSettings(BaseSettings):
         model: str = default_args.model
         model_name: str = default_args.model_name
+        extra_information: Optional[str] = default_args.extra_information
         served_model_name: Optional[Union[str, List[str]]] = None
         tokenizer: Optional[str] = default_args.tokenizer
         task: TaskOption = default_args.task
@@ -271,6 +273,10 @@ def get_parser() -> FlexibleArgumentParser:
                         type=str,
                         default=DEFAULT_MODEL_NAME,
                         help="The name of the model given by the /info endpoint of the API")
+    parser.add_argument("--extra-information",
+                        type=str,
+                        default=DEFAULT_EXTRA_INFORMATION,
+                        help="The path to a json to add to the /info endpoint of the API")
     parser.add_argument("--app-name",
                         type=str,
                         default=application_settings.app_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,8 @@ os.environ['HF_TOKEN'] = huggingface_settings.hf_token
 
 # Set paths
 TEST_DIR = Path(__file__).parent.resolve()
-TEST_MODELS_DIR = TEST_DIR / "data" / "models"
+TEST_DATA_DIR = TEST_DIR / "data"
+TEST_MODELS_DIR = TEST_DATA_DIR / "models"
 
 # Set environment variables for testing
 os.environ["app_name"] = "APP_TESTS"
@@ -101,7 +102,8 @@ async def test_base_client() -> AsyncClient:
         allowed_headers=["*"],
         root_path=None,
         with_launch_arguments=True,
-        disable_fastapi_docs=False
+        disable_fastapi_docs=False,
+        extra_information=str(TEST_DATA_DIR / "extra_information.json")
     )
     app = await declare_application(happy_vllm_build_async_engine_client(args), args)
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test", follow_redirects=True)
@@ -126,7 +128,8 @@ async def test_complete_client(monkeypatch) -> AsyncClient:
         allowed_headers=["*"],
         root_path=None,
         with_launch_arguments=True,
-        disable_fastapi_docs=False
+        disable_fastapi_docs=False,
+        extra_information=str(TEST_DATA_DIR / "extra_information.json")
     )
     app = await declare_application(happy_vllm_build_async_engine_client(args), args)
     async with LifespanManager(app) as manager:

--- a/tests/data/extra_information.json
+++ b/tests/data/extra_information.json
@@ -1,0 +1,8 @@
+{
+    "argument_1": "Hey",
+    "argument_2": 42,
+    "argument_3": true,
+    "argument_4": {
+        "internal_argument": 23
+    }
+}

--- a/tests/test_routers_technical.py
+++ b/tests/test_routers_technical.py
@@ -15,11 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import json
 import shutil
 import pytest
 from httpx import AsyncClient
 
-from .conftest import TEST_MODELS_DIR
+from .conftest import TEST_MODELS_DIR, TEST_DATA_DIR
 
 
 from happy_vllm import utils
@@ -66,6 +67,11 @@ async def test_info(test_complete_client: AsyncClient):
     assert response_json["model_name"] == "TEST MODEL"
     assert response_json["truncation_side"] == "right"
     assert response_json["max_length"] == 2048
+    with open(TEST_DATA_DIR / "extra_information.json", "r") as json_file:
+        target_extra_information = json.load(json_file)
+    assert set(response_json["extra_information"]) == set(target_extra_information)
+    for key, value in target_extra_information.items():
+        response_json["extra_information"][key] == value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add the possibility to specify a .json when launching the API so that it is displayed in the field "extra_information" of the route /v1/info